### PR TITLE
Correct deal-start detection

### DIFF
--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ var rollup = &cli.Command{
 
 		for dealID, dealInfo := range deals {
 
-			// Only count deals that have properly started, not past/future ones
+			// Only count deals whose sectors have properly started, not past/future ones
 			// https://github.com/filecoin-project/specs-actors/blob/v0.9.9/actors/builtin/market/deal.go#L81-L85
 			// Bail on 0 as well in case SectorStartEpoch is uninitialized due to some bug
 			if dealInfo.State.SectorStartEpoch <= 0 ||
@@ -211,13 +211,14 @@ var rollup = &cli.Command{
 				resolvedWallets[dealInfo.Proposal.Client] = clientAddr
 			}
 
+			// Cut off deals from previous phase
 			//
 			// perl -E 'say scalar gmtime ( XXX * 30 + 1598306400 )'
 			//
 			// 166560: Wed Oct 21 18:00:00 2020
 			// 307680: Wed Dec  9 18:00:00 2020
 			// 448800: Wed Jan 27 18:00:00 2021
-			if dealInfo.Proposal.StartEpoch <= 448800 {
+			if dealInfo.State.SectorStartEpoch <= 448800 {
 				continue
 			}
 


### PR DESCRIPTION
In filecoin the payment of a deal can start way later than the actual
sector containing it. This makes the deal retrievable but the accrual of
payment for it is delayed. This is usually done to allow ample time for
sealing to take place, as the start of proving of a containing sector
must be strictly before the deal start.

Within the entire codebase we properly go off dealInfo.State.SectorStartEpoch
except for one forgotten spot, which this commit corrects.

This has very minor implications for the results of the last round of the
competition, inflating the winning numbers by 0.7% ( that's 0.0071 ).
No effort will be taken to correct/exclude any of the deals retroactively.

Going forward the stats should be entirely correct.