### PR TITLE
Chore: Update start epoch for phase 2.6

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,8 +34,8 @@ var defaultEpochLookback = abi.ChainEpoch(10)
 // 569760:  Wed Mar 10 18:00:00 2021
 // 756960:  Fri May 14 18:00:00 2021
 // 912480:  Wed Jul  7 18:00:00 2021
-// 1099670: Fri Sep 10 18:00:00 2021
-var currentPhaseStart = abi.ChainEpoch(1099670)
+// 1099680: Fri Sep 10 18:00:00 2021
+var currentPhaseStart = abi.ChainEpoch(1099680)
 
 //
 // contents of basic_stats.json

--- a/main.go
+++ b/main.go
@@ -28,13 +28,14 @@ var defaultEpochLookback = abi.ChainEpoch(10)
 
 // perl -E 'say scalar gmtime ( XXX * 30 + 1598306400 )'
 //
-// 166560: Wed Oct 21 18:00:00 2020
-// 307680: Wed Dec  9 18:00:00 2020
-// 448800: Wed Jan 27 18:00:00 2021
-// 569760: Wed Mar 10 18:00:00 2021
-// 756960: Fri May 14 18:00:00 2021
-// 912480: Wed Jul  7 18:00:00 2021
-var currentPhaseStart = abi.ChainEpoch(912480)
+// 166560:  Wed Oct 21 18:00:00 2020
+// 307680:  Wed Dec  9 18:00:00 2020
+// 448800:  Wed Jan 27 18:00:00 2021
+// 569760:  Wed Mar 10 18:00:00 2021
+// 756960:  Fri May 14 18:00:00 2021
+// 912480:  Wed Jul  7 18:00:00 2021
+// 1099670: Fri Sep 10 18:00:00 2021
+var currentPhaseStart = abi.ChainEpoch(1099670)
 
 //
 // contents of basic_stats.json


### PR DESCRIPTION
2.6 starts on Friday, Sep 10, 2021 at 18:00 UTC @ribasushi.

Epoch for phase start is updated to `1099680`

```zsh
> perl -E 'say scalar gmtime ( 1099680 * 30 + 1598306400 )'
Fri Sep 10 18:00:00 2021
```