### PR TITLE
chore: Update start epoch for phase 2.7

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,7 +35,8 @@ var defaultEpochLookback = abi.ChainEpoch(10)
 // 756960:  Fri May 14 18:00:00 2021
 // 912480:  Wed Jul  7 18:00:00 2021
 // 1099680: Fri Sep 10 18:00:00 2021
-var currentPhaseStart = abi.ChainEpoch(1099680)
+// 1275360: Wed Nov 10 18:00:00 2021
+var currentPhaseStart = abi.ChainEpoch(1275360)
 
 //
 // contents of basic_stats.json


### PR DESCRIPTION
2.7 starts on Friday, Nov 10, 2021 at 18:00 UTC @ribasushi.

Epoch for phase start is updated to `1275360`

```zsh
> perl -E 'say scalar gmtime ( 1275360 * 30 + 1598306400 )'
Wed Nov 10 18:00:00 2021
```
