### PR TITLE
chore: update start epoch for phase 2.8

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,7 +38,8 @@ var defaultEpochLookback = abi.ChainEpoch(10)
 // 912480:  Wed Jul  7 18:00:00 2021
 // 1099680: Fri Sep 10 18:00:00 2021
 // 1275360: Wed Nov 10 18:00:00 2021
-var currentPhaseStart = abi.ChainEpoch(1275360)
+// 1623840: Fri Mar 11 18:00:00 2021
+var currentPhaseStart = abi.ChainEpoch(1623840)
 
 // 1381920: Fri Dec 17 18:00:00 2021
 var recoveryStart = abi.ChainEpoch(1381920)


### PR DESCRIPTION
2.8 starts today, Friday, Mar 11, 2022 at 18:00 UTC @ribasushi.

Epoch for phase start is updated to `1623840`

```zsh
> perl -E 'say scalar gmtime ( 1623840 * 30 + 1598306400 )'
Wed Nov 10 18:00:00 2021
```
